### PR TITLE
Upgrade xpath for perf gains (0.28) and max callstack fixes (0.31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "cheerio": "0.22.0",
     "xmldom": "0.1.27",
-    "xpath": "0.0.27"
+    "xpath": "0.0.32"
   }
 }


### PR DESCRIPTION
[This performance improvement](https://github.com/goto100/xpath/commit/be990467125cdede17a424c19d7e32e0e1373726) was made available in [0.28](https://github.com/goto100/xpath/commit/ca98ad4e3db89ed6338e3b771898d196a654d6bd) and [callstack fixes](https://github.com/goto100/xpath/commit/b62c28166de701c5b067658bfe94fe54f01ec0c6) were made available in [0.31](https://github.com/goto100/xpath/commit/435dfa762796a43cdee80138900edd0307590aff). This is (at least) a 2x performance improvement for Talon and also allows us to increase the limits without running into fatal errors.

Attached an execution flamegraph which shows that the vast majority of time spent is within `xpath`.

<img width="1823" alt="Screenshot 2023-06-09 at 11 11 11 AM" src="https://github.com/frontapp/talonjs/assets/3486978/16251332-73b7-4229-8810-6e7cb9e9df78">

[15495.0x.zip](https://github.com/frontapp/talonjs/files/11709058/15495.0x.zip)

There maybe some value in updating `xmldom` because of improvements to their dependencies, but I didn't see any major performance improvements introduced directly to `xmldom`.